### PR TITLE
Use client-extension.yaml instead of client-extension-config.json

### DIFF
--- a/resources/partial/notification-type-springboot/append/client-extension.yaml
+++ b/resources/partial/notification-type-springboot/append/client-extension.yaml
@@ -1,6 +1,7 @@
 ${id}-user-agent:
   type: oAuthApplicationUserAgent
 
-assemble:
-  - include:
-    - "*.client-extension-config.json"
+${id}-notification-type:
+  type: notificationType
+  resourcePath: ${resourcePath}
+  oAuth2ApplicationExternalReferenceCode: ${id}-user-agent

--- a/resources/partial/notification-type-springboot/overwrite/${id}-notification-type.client-extension-config.json
+++ b/resources/partial/notification-type-springboot/overwrite/${id}-notification-type.client-extension-config.json
@@ -1,8 +1,0 @@
-{
-  "com.liferay.notification.internal.configuration.FunctionNotificationTypeConfiguration~${id}" : {
-    "baseURL" : "${portalURL}/o/${id}",
-    "dxp.lxc.liferay.com.virtualInstanceId" : "default",
-    "oAuth2ApplicationExternalReferenceCode" : "${id}-user-agent",
-    "resourcePath" : "${resourcePath}"
-  }
-}


### PR DESCRIPTION
Hello team,

It's an old request made to me, it's about use properties of client-extension.yaml instead of client-extension-config.json.

Unfortunately a lot of tasks were assigned to me and I didn't had time to do this changes previously.

Best regards,
Feliphe