### PR TITLE
stabilize

### DIFF
--- a/scripts/k8s/create.py
+++ b/scripts/k8s/create.py
@@ -9,6 +9,6 @@ tmpfile = "/tmp/.%s.yaml" % name
 with open(tmpfile, "w") as f:
     f.write(ytt.generate_workload_yaml())
 
-applied_yaml = os.popen("kubectl create -oyaml -f %s" % tmpfile).read()
+applied_yaml = os.popen("kubectl apply -oyaml -f %s 2>/dev/null" % tmpfile).read()
 
 print(applied_yaml)

--- a/scripts/k8s/token.sh
+++ b/scripts/k8s/token.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-kubectl get secret default-token --context 'k3d-localdev' -o jsonpath='{.data.token}' | \
+kubectl get secret default-token --context 'k3d-localdev' -o jsonpath='{.data.token}' 2>/dev/null | \
 	base64 --decode

--- a/scripts/runtime/create.sh
+++ b/scripts/runtime/create.sh
@@ -79,8 +79,8 @@ ADDRESS=""
 echo "DOCKER_HOST_ADDRESS: waiting..."
 until [ "${ADDRESS}" != "" ]; do
 	ADDRESS=$(\
-		kubectl get cm coredns --namespace kube-system \
-		-o jsonpath='{.data.NodeHosts}' 2>/dev/null \
+			kubectl get cm coredns --namespace kube-system \
+			-o jsonpath='{.data.NodeHosts}' 2>/dev/null \
 		| grep host.k3d.internal | awk '{print $1}')
 	sleep 1
 done
@@ -93,7 +93,7 @@ CRD=""
 echo "INGRESSROUTE_CRD: waiting..."
 until [ "$CRD" != "" ]; do
 	CRD=$(\
-		kubectl get crd ingressroutes.traefik.containo.us \
+			kubectl get crd ingressroutes.traefik.containo.us \
 		--ignore-not-found 2>/dev/null)
 	sleep 1
 done

--- a/scripts/runtime/start.sh
+++ b/scripts/runtime/start.sh
@@ -14,11 +14,9 @@ CLUSTER=$(k3d cluster list -o json | jq -r '.[] | select(.name=="localdev")')
 # is cluster running?
 CLUSTER_STATUS=$(jq -r '.serversRunning > 0' <<< $CLUSTER)
 
-if [ "$CLUSTER_STATUS" == "true" ];then
-	echo "'localdev' runtime environment is started."
-	exit 0
+if [ "$CLUSTER_STATUS" != "true" ];then
+	echo "'localdev' runtime environment is not started."
+	exit 1
 fi
-
-k3d cluster start localdev
 
 echo "'localdev' runtime environment is started."

--- a/scripts/runtime/stop.sh
+++ b/scripts/runtime/stop.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+REPO="${LOCALDEV_REPO:-/repo}"
+
+${REPO}/scripts/ext/stop.sh
+
 k3d cluster stop localdev
 
 # Ignore the result of the following command


### PR DESCRIPTION
- stop ext before cluster so that on_down() actions in Tiltfile are triggered
- avoid logging superfluous client error output
- recover from rt stop without having to resort to rt delete
