### PR TITLE
stabilize

### DIFF
--- a/resources/tilt/Tiltfile.dockerVolume
+++ b/resources/tilt/Tiltfile.dockerVolume
@@ -4,15 +4,27 @@ load("ext://uibutton", "cmd_button", "text_input", "location")
 dxp_data_volume = "dxpData"
 
 # api docs for adding UIButtons found here: https://docs.tilt.dev/buttons.html
+
 cmd_button(
-    "Kill DXP && Drop Docker Volume!",
+    "Kill DXP!",
     argv=[
         "sh",
         "-c",
-        "docker container rm -f dxp-server && docker volume rm %s" % dxp_data_volume,
+        "docker container rm -f dxp-server",
     ],
     resource="dxp.lfr.dev",
     icon_name="delete",
-    text="Kill DXP && Drop Docker Volume!"
-    # inputs=[text_input("VOLUME", default=dxp_data_volume)],
+    text="Kill DXP!",
+)
+
+cmd_button(
+    "Drop DXP Data Volume!",
+    argv=[
+        "sh",
+        "-c",
+        "docker volume rm -f %s" % dxp_data_volume,
+    ],
+    resource="dxp.lfr.dev",
+    icon_name="delete",
+    text="Drop DXP Data Volume!",
 )

--- a/resources/tilt/Tiltfile.mysql
+++ b/resources/tilt/Tiltfile.mysql
@@ -4,33 +4,9 @@ load("ext://uibutton", "cmd_button", "text_input", "location")
 db_container_name = "mysql"
 db_username = "dxpcloud"
 db_password = "passw0rd"
-dxp_data_volume = "dxpData"
 mysql_data_volume = "mysqlData"
 
 # api docs for adding UIButtons found here: https://docs.tilt.dev/buttons.html
-cmd_button(
-    "Kill DXP!",
-    argv=[
-        "sh",
-        "-c",
-        "docker container rm -f dxp-server",
-    ],
-    resource="dxp.lfr.dev",
-    icon_name="delete",
-    text="Kill DXP!",
-)
-
-cmd_button(
-    "Drop DXP Data Volume!",
-    argv=[
-        "sh",
-        "-c",
-        "docker volume rm -f %s" % dxp_data_volume,
-    ],
-    resource="dxp.lfr.dev",
-    icon_name="delete",
-    text="Drop DXP Data Volume!",
-)
 
 cmd_button(
     "Kill mysql!",
@@ -68,6 +44,7 @@ dxp_buildargs = {
 # To see full list of ENV VARs supported see portal.properties for possible ENVs
 # https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/portal.properties
 dxp_envs = {
+    "DATABASE_PERIOD_PARTITION_PERIOD_ENABLED": "true",
     "LIFERAY_USERS_PERIOD_REMINDER_PERIOD_QUERIES_PERIOD_ENABLED": "false",
     "LCP_PROJECT_ENVIRONMENT": "local",
     "LCP_PROJECT_ID": "local",
@@ -130,7 +107,6 @@ local_resource(
         ),
     ),
 )
-
 
 def on_down():
     local("docker container stop %s" % db_container_name)

--- a/resources/tilt/Tiltfile.mysql
+++ b/resources/tilt/Tiltfile.mysql
@@ -60,7 +60,7 @@ cmd_button(
 # To see all buildargs seeSee
 # https://github.com/liferay/liferay-localdev/blob/main/docker/images/dxp-server/Dockerfile
 dxp_buildargs = {
-    "DXP_BASE_IMAGE": "liferay/dxp:7.4.13.nightly-d5.0.2-20221109134152",
+    # "DXP_BASE_IMAGE": "liferay/dxp:latest",
 }
 
 

--- a/scripts/k8s/create.py
+++ b/scripts/k8s/create.py
@@ -9,6 +9,6 @@ tmpfile = "/tmp/.%s.yaml" % name
 with open(tmpfile, "w") as f:
     f.write(ytt.generate_workload_yaml())
 
-applied_yaml = os.popen("kubectl create -oyaml -f %s" % tmpfile).read()
+applied_yaml = os.popen("kubectl apply -oyaml -f %s 2>/dev/null" % tmpfile).read()
 
 print(applied_yaml)

--- a/scripts/k8s/token.sh
+++ b/scripts/k8s/token.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-kubectl get secret default-token --context 'k3d-localdev' -o jsonpath='{.data.token}' | \
+kubectl get secret default-token --context 'k3d-localdev' -o jsonpath='{.data.token}' 2>/dev/null | \
 	base64 --decode

--- a/scripts/runtime/create.sh
+++ b/scripts/runtime/create.sh
@@ -79,8 +79,8 @@ ADDRESS=""
 echo "DOCKER_HOST_ADDRESS: waiting..."
 until [ "${ADDRESS}" != "" ]; do
 	ADDRESS=$(\
-		kubectl get cm coredns --namespace kube-system \
-		-o jsonpath='{.data.NodeHosts}' 2>/dev/null \
+			kubectl get cm coredns --namespace kube-system \
+			-o jsonpath='{.data.NodeHosts}' 2>/dev/null \
 		| grep host.k3d.internal | awk '{print $1}')
 	sleep 1
 done
@@ -93,7 +93,7 @@ CRD=""
 echo "INGRESSROUTE_CRD: waiting..."
 until [ "$CRD" != "" ]; do
 	CRD=$(\
-		kubectl get crd ingressroutes.traefik.containo.us \
+			kubectl get crd ingressroutes.traefik.containo.us \
 		--ignore-not-found 2>/dev/null)
 	sleep 1
 done

--- a/scripts/runtime/start.sh
+++ b/scripts/runtime/start.sh
@@ -14,11 +14,9 @@ CLUSTER=$(k3d cluster list -o json | jq -r '.[] | select(.name=="localdev")')
 # is cluster running?
 CLUSTER_STATUS=$(jq -r '.serversRunning > 0' <<< $CLUSTER)
 
-if [ "$CLUSTER_STATUS" == "true" ];then
-	echo "'localdev' runtime environment is started."
-	exit 0
+if [ "$CLUSTER_STATUS" != "true" ];then
+	echo "'localdev' runtime environment is not started."
+	exit 1
 fi
-
-k3d cluster start localdev
 
 echo "'localdev' runtime environment is started."

--- a/scripts/runtime/stop.sh
+++ b/scripts/runtime/stop.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+REPO="${LOCALDEV_REPO:-/repo}"
+
+${REPO}/scripts/ext/stop.sh
+
 k3d cluster stop localdev
 
 # Ignore the result of the following command

--- a/tests/functional/test-mysql-volume.sh
+++ b/tests/functional/test-mysql-volume.sh
@@ -47,7 +47,7 @@ $CLI ext create \
 
 # copy the Tiltfile.mysql into workspace
 
-cp ${LOCALDEV_REPO}/resources/tilt/Tiltfile.mysql ${WORKSPACE_BASE_PATH}/Tiltfile
+cp ${LOCALDEV_REPO}/resources/tilt/Tiltfile.mysql ${WORKSPACE_BASE_PATH}/
 
 $CLI ext start -d ${WORKSPACE_BASE_PATH} &
 

--- a/tests/functional/test-mysql-volume.sh
+++ b/tests/functional/test-mysql-volume.sh
@@ -41,7 +41,9 @@ $CLI ext create \
 	--noprompt \
 	-- \
 	--resource-path="template/global-css" \
-	--workspace-path="test-global-css"
+	--workspace-path="test-global-css" \
+	--args=id="test-global-css" \
+	--args=name="Test Global CSS"
 
 # copy the Tiltfile.mysql into workspace
 

--- a/tests/functional/test-mysql-volume.sh
+++ b/tests/functional/test-mysql-volume.sh
@@ -49,7 +49,7 @@ $CLI ext create \
 
 cp ${LOCALDEV_REPO}/resources/tilt/Tiltfile.mysql ${WORKSPACE_BASE_PATH}/
 
-$CLI ext start -d ${WORKSPACE_BASE_PATH} &
+$CLI ext start -v -d ${WORKSPACE_BASE_PATH} &
 
 FOUND_LOCALDEV_SERVER=0
 
@@ -73,7 +73,6 @@ until [ "$FOUND_EXT_PROVISION_CONFIG_MAPS" == "1" ]; do
 	sleep 5
 	FOUND_EXT_PROVISION_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-provision-metadata | wc -l | xargs)
 	echo "FOUND_EXT_PROVISION_CONFIG_MAPS=${FOUND_EXT_PROVISION_CONFIG_MAPS}"
-	docker logs -n 50 localdev-extension-runtime
 done
 
 $CLI ext stop -v

--- a/tests/functional/test-mysql-volume.sh
+++ b/tests/functional/test-mysql-volume.sh
@@ -71,7 +71,7 @@ FOUND_EXT_PROVISION_CONFIG_MAPS=0
 
 until [ "$FOUND_EXT_PROVISION_CONFIG_MAPS" == "1" ]; do
 	sleep 5
-	FOUND_EXT_PROVISION_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-provision-metadata | wc -l | xargs)
+	FOUND_EXT_PROVISION_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime kubectl get cm | grep ext-provision-metadata | wc -l | xargs)
 	echo "FOUND_EXT_PROVISION_CONFIG_MAPS=${FOUND_EXT_PROVISION_CONFIG_MAPS}"
 done
 

--- a/tests/functional/test-new-casc-projects.sh
+++ b/tests/functional/test-new-casc-projects.sh
@@ -58,7 +58,7 @@ done
 FOUND_EXT_PROVISION_CONFIG_MAPS=0
 
 until [ "$FOUND_EXT_PROVISION_CONFIG_MAPS" == "1" ]; do
-	sleep 60
+	sleep 5
 	FOUND_EXT_PROVISION_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-provision-metadata | wc -l | xargs)
 	echo "FOUND_EXT_PROVISION_CONFIG_MAPS=${FOUND_EXT_PROVISION_CONFIG_MAPS}"
 	docker logs -n 50 localdev-extension-runtime
@@ -67,7 +67,7 @@ done
 FOUND_EXT_INIT_CONFIG_MAPS=0
 
 until [ "$FOUND_EXT_INIT_CONFIG_MAPS" == "1" ]; do
-	sleep 60
+	sleep 5
 	FOUND_EXT_INIT_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-init-metadata | wc -l | xargs)
 	echo "FOUND_EXT_INIT_CONFIG_MAPS=${FOUND_EXT_INIT_CONFIG_MAPS}"
 	docker logs -n 50 localdev-extension-runtime

--- a/tests/functional/test-new-casc-projects.sh
+++ b/tests/functional/test-new-casc-projects.sh
@@ -61,7 +61,6 @@ until [ "$FOUND_EXT_PROVISION_CONFIG_MAPS" == "1" ]; do
 	sleep 5
 	FOUND_EXT_PROVISION_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-provision-metadata | wc -l | xargs)
 	echo "FOUND_EXT_PROVISION_CONFIG_MAPS=${FOUND_EXT_PROVISION_CONFIG_MAPS}"
-	docker logs -n 50 localdev-extension-runtime
 done
 
 FOUND_EXT_INIT_CONFIG_MAPS=0
@@ -70,7 +69,6 @@ until [ "$FOUND_EXT_INIT_CONFIG_MAPS" == "1" ]; do
 	sleep 5
 	FOUND_EXT_INIT_CONFIG_MAPS=$(docker exec -i localdev-extension-runtime /entrypoint.sh kubectl get cm | grep ext-init-metadata | wc -l | xargs)
 	echo "FOUND_EXT_INIT_CONFIG_MAPS=${FOUND_EXT_INIT_CONFIG_MAPS}"
-	docker logs -n 50 localdev-extension-runtime
 done
 
 $CLI ext stop -v


### PR DESCRIPTION
- stop ext before cluster so that on_down() actions in Tiltfile are triggered
- avoid logging superfluous client error output
- recover from rt stop without having to resort to rt delete
- SF
- remove old image reference
- refactor Tilefile.* so they can be used together without merging
- add missing template arguments
- less sleep for better responsiveness
- just copy the file
- verbose output so we don't have to dump logs
- remove extra argument
