### PR TITLE
LPS-181325 run local images as root to avoid mkcert permission issues

### DIFF
--- a/k8s/workloads/cronjob/cronjob.yaml
+++ b/k8s/workloads/cronjob/cronjob.yaml
@@ -26,6 +26,8 @@ spec:
               limits:
                 memory: #@ data.values.memory
                 cpu: #@ data.values.cpu
+            securityContext:
+              runAsUser: 0
             volumeMounts:
               - mountPath: /etc/liferay/lxc/dxp-metadata
                 name: lxc-dxp-metadata

--- a/k8s/workloads/deployment/deployment.yaml
+++ b/k8s/workloads/deployment/deployment.yaml
@@ -38,6 +38,8 @@ spec:
             path: #@ data.values.readyPath
             port: #@ data.values.targetPort
         #@ end
+        securityContext:
+          runAsUser: 0
         volumeMounts:
           #@ if data.values.dxpMetadata:
           - mountPath: /etc/liferay/lxc/dxp-metadata

--- a/k8s/workloads/job/job.yaml
+++ b/k8s/workloads/job/job.yaml
@@ -23,6 +23,8 @@ spec:
           limits:
             memory: #@ data.values.memory
             cpu: #@ data.values.cpu
+        securityContext:
+          runAsUser: 0
         volumeMounts:
           - mountPath: /etc/liferay/lxc/dxp-metadata
             name: lxc-dxp-metadata


### PR DESCRIPTION
hey @rotty3000  sanity check, but running these user/client-extension containers as root, is that gonna run into file permission problems that we ran into before?  Or is all of those permission issues having to do with localdev container and the ext dir and such.